### PR TITLE
[feat] 읽지 않은 알림 개수 실시간 표시 기능 구현

### DIFF
--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -65,3 +65,11 @@ export const deleteNotification = async (params: {
   );
   return response.data;
 };
+
+// 읽지 않은 알림 개수 조회
+export const getUnreadCount = async (userId: number): Promise<number> => {
+  const response = await apiClient.get<number>(
+    `/notifications/unread-count?userId=${userId}`
+  );
+  return response.data;
+};

--- a/src/components/layout/default/Header.tsx
+++ b/src/components/layout/default/Header.tsx
@@ -1,6 +1,56 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { getUnreadCount } from '../../../api/notification';
+import { getUserIdFromToken } from '../../../utils/auth';
 
 export default function Header() {
+  const [unreadCount, setUnreadCount] = useState<number>(0);
+
+  useEffect(() => {
+    const fetchUnreadCount = async () => {
+      try {
+        const token = localStorage.getItem('accessToken');
+        if (!token) return;
+        
+        const userId = getUserIdFromToken(token);
+        if (!userId) return;
+        
+        const count = await getUnreadCount(userId);
+        setUnreadCount(count);
+      } catch (error) {
+        console.error('Failed to fetch unread count:', error);
+      }
+    };
+
+    // 초기 로드
+    fetchUnreadCount();
+
+    // 주기적으로 업데이트 (30초마다)
+    const interval = setInterval(fetchUnreadCount, 30000);
+
+    // SSE 이벤트 리스너 추가
+    const handleUnreadCountUpdated = (event: CustomEvent) => {
+      console.log('Unread count updated via SSE:', event.detail);
+      if (event.detail && typeof event.detail.count === 'number') {
+        setUnreadCount(event.detail.count);
+      }
+    };
+
+    const handleNotificationReceived = () => {
+      // 새 알림이 올 때 카운트 다시 조회
+      fetchUnreadCount();
+    };
+
+    window.addEventListener('unread-count-updated', handleUnreadCountUpdated as EventListener);
+    window.addEventListener('notification-received', handleNotificationReceived);
+
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('unread-count-updated', handleUnreadCountUpdated as EventListener);
+      window.removeEventListener('notification-received', handleNotificationReceived);
+    };
+  }, []);
+
   return (
     <header className="h-full bg-white border-b border-gray-100">
       <div className="h-full flex items-center justify-between px-4">
@@ -24,9 +74,11 @@ export default function Header() {
             className="w-10 h-10 flex items-center justify-center rounded-full bg-gray-50 hover:bg-gray-100 transition-colors relative"
           >
             <i className="ri-notification-2-line text-gray-600 text-lg"></i>
-            <span className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 rounded-full flex items-center justify-center text-xs text-white">
-              3
-            </span>
+            {unreadCount > 0 && (
+              <span className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 rounded-full flex items-center justify-center text-xs text-white">
+                {unreadCount > 99 ? '99+' : unreadCount}
+              </span>
+            )}
           </Link>
         </div>
       </div>


### PR DESCRIPTION

## #️⃣ Issue Number

#85

## 📝 요약(Summary)

- notification API에 unread-count 엔드포인트 추가
- Header 컴포넌트에 실제 알림 개수 연동
- JWT 토큰에서 userId 추출하여 알림 개수 조회
- 30초마다 자동 업데이트 및 SSE 실시간 업데이트 지원
- 알림 99개 초과 시 99+ 표시

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
