### PR TITLE
[fix] 모임 수정 시 기존 관심사와 지역 정보가 선택된 상태로 표시되도록 수정

### DIFF
--- a/src/components/common/AddressSelector.tsx
+++ b/src/components/common/AddressSelector.tsx
@@ -64,6 +64,16 @@ const AddressSelector: React.FC<AddressSelectorProps> = ({
   const cityScrollRef = useRef<HTMLDivElement>(null);
   const districtScrollRef = useRef<HTMLDivElement>(null);
 
+  // initialCity와 initialDistrict가 변경될 때 상태 업데이트
+  useEffect(() => {
+    if (initialCity) {
+      setSelectedCity(initialCity);
+    }
+    if (initialDistrict) {
+      setSelectedDistrict(initialDistrict);
+    }
+  }, [initialCity, initialDistrict]);
+
   const cities = Object.keys(typedKoreaData.korea_administrative_divisions);
   const districts = selectedCity
     ? typedKoreaData.korea_administrative_divisions[selectedCity]?.districts ||

--- a/src/components/domain/meeting/MeetingForm.tsx
+++ b/src/components/domain/meeting/MeetingForm.tsx
@@ -61,11 +61,13 @@ export const MeetingForm = ({
 
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [selectedAddress, setSelectedAddress] = useState<AddressData>({
-    city: '',
-    district: '',
-    isComplete: false,
-  });
+  const [selectedAddress, setSelectedAddress] = useState<AddressData>(
+    initialData?.address || {
+      city: '',
+      district: '',
+      isComplete: false,
+    }
+  );
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

- AddressSelector: props 변경 시 상태 업데이트하는 useEffect 추가
- MeetingForm: selectedAddress 초기값을 initialData.address로 설정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AddressSelector: 외부에서 초기 city/district 값이 변경될 때 선택 상태와 구/군 목록이 즉시 동기화되어 화면에 올바르게 반영됩니다.
  * MeetingForm: 초기 데이터에 주소가 있을 경우 첫 렌더에서 주소가 자동으로 채워지며, 이전에 빈 값으로 시작하던 흐름을 수정했습니다.
  * 편집 모드나 폼 재로딩 시 주소 선택값이 정확히 표시되어 재선택 필요가 줄어듭니다. 화면 동작만 변경되며 외부 API나 설정 변경은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->